### PR TITLE
fix: Latest Devcontainer feature is not compatible

### DIFF
--- a/.devcontainer/python/Dockerfile
+++ b/.devcontainer/python/Dockerfile
@@ -1,26 +1,13 @@
+FROM continuumio/miniconda3:23.10.0-1 AS conda
+
+# Do nothing, just get miniconda image
+
 FROM ubuntu:22.04
 
-ARG CONDA_INSTALL
-ARG tmp_conda=/tmp/miniconda.sh
-ENV CONDA_INSTALL=${CONDA_INSTALL:-/opt/conda}
-
 # hadolint ignore=DL3008
-RUN apt-get update && apt-get install wget curl -y --no-install-recommends \
+RUN apt-get update && apt-get install wget curl ca-certificates -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
-RUN <<EOF
-  arch=$(uname -m)
-  if [ "$arch" = "x86_64" ]; then
-    MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh";
-  elif [ "$arch" = "aarch64" ]; then
-    MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh";
-  else
-    echo "Unsupported architecture: $arch";
-    exit 1;
-  fi
-  wget $MINICONDA_URL -O $tmp_conda -q
-EOF
+COPY --from=conda /opt/conda /opt/conda
 
-RUN bash $tmp_conda -b -p $CONDA_INSTALL \
-  && chmod a+w -R $CONDA_INSTALL \
-  && rm -f $tmp_conda
+ENV PATH=/opt/conda/bin:$PATH

--- a/.devcontainer/python/devcontainer.json
+++ b/.devcontainer/python/devcontainer.json
@@ -5,13 +5,11 @@
   "build": {
     "dockerfile": "Dockerfile",
     "context": ".",
-    "args": {
-      "CONDA_INSTALL": "/opt/miniconda3"
-    }
+    "args": {}
   },
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
-    "ghcr.io/devcontainers/features/common-utils:2": {
+    "ghcr.io/devcontainers/features/common-utils:2.5.1": {
       "configureZshAsDefaultShell": true
     }
   },

--- a/.devcontainer/terraform/Dockerfile
+++ b/.devcontainer/terraform/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
 
 # hadolint ignore=DL3008
-RUN apt-get update && apt-get install wget curl unzip git git-lfs -y --no-install-recommends \
+RUN apt-get update && apt-get install wget curl ca-certificates unzip git git-lfs -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/terraform/devcontainer.json
+++ b/.devcontainer/terraform/devcontainer.json
@@ -10,24 +10,27 @@
   },
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
-    "aws-cli": "latest",
-    "ghcr.io/devcontainers/features/common-utils:2": {},
+    // Version of devcontainer features to use https://github.com/orgs/devcontainers/packages?repo_name=features
+    "ghcr.io/devcontainers/features/aws-cli:1.1": {},
+    "ghcr.io/devcontainers/features/common-utils:2.5.1": {},
     // Installs the Terraform CLI and optionally TFLint, Terragrunt, sentinel, tfsec, terraform-docs.
     // https://github.com/devcontainers/features/blob/main/src/terraform/README.md#options
-    "ghcr.io/devcontainers/features/terraform:1": {
-      "version": "latest",
-      "tflint": "latest",
-      "terragrunt": "latest",
+    "ghcr.io/devcontainers/features/terraform:1.3.8": {
+      "version": "1.9.0",
+      "tflint": "0.47.0",
+      "terragrunt": "0.67.14",
       "installSentinel": true,
       "installTFsec": true,
       "installTerraformDocs": true
       // "httpProxy": "http://proxy:8080",
     },
-    "ghcr.io/devcontainers/features/python:1": {
+    "ghcr.io/devcontainers/features/python:1.6.4": {
       "version": "3.9"
     },
-    "ghcr.io/devcontainers-contrib/features/infracost:1": {},
-    "ghcr.io/devcontainers-contrib/features/terrascan:1": {
+    "ghcr.io/devcontainers-contrib/features/infracost:1.0.5": {
+      "version": "0.10.39"
+    },
+    "ghcr.io/devcontainers-contrib/features/terrascan:1.0.1": {
       "version": "1.19.1"
     },
     // "ghcr.io/flexwie/devcontainer-features/terraspace:1": {}
@@ -38,13 +41,13 @@
     // "ghcr.io/devcontainers-contrib/features/tfswitch:1": {},
     // "ghcr.io/mickeahlinder/devcontainer-features/tfenv:1": {},
     // "ghcr.io/joshuanianji/devcontainer-features/terraform-cli-persistence:1": {},
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2.12.0": {
       "dockerDashComposeVersion": "none",
       "installDockerBuildx": false
     },
-    "ghcr.io/customink/codespaces-features/sam-cli:1": {}
-    // "ghcr.io/audacioustux/devcontainers/aws-sam-cli:1": {},
-    // "ghcr.io/goldsam/dev-container-features/aws-sam-cli:1": {}
+    "ghcr.io/customink/codespaces-features/sam-cli:1.0.1": {
+      "version": "1.123.0"
+    }
   },
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "scripts/devcontainer/post-create.sh",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,11 +43,14 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
-  - repo: https://github.com/hadolint/hadolint
-    rev: v2.12.0
+  - repo: local
     hooks:
-      - id: hadolint
-        description: Dockerfile linter
+      - id: hadolint-docker
+        name: Lint Dockerfiles
+        description: Runs hadolint Docker image to lint Dockerfiles
+        language: docker_image
+        types: ["dockerfile"]
+        entry: ghcr.io/hadolint/hadolint hadolint
         args: [
           '--ignore', 'DL3007', # Using latest
           '--ignore', 'DL3013', # Pin versions in pip

--- a/scripts/devcontainer/conda-activate.sh
+++ b/scripts/devcontainer/conda-activate.sh
@@ -1,7 +1,6 @@
 #!/bin/zsh
 
-conda=$CONDA_INSTALL/bin/conda
-$conda init --all
+conda init --all
 
-$conda create -n py$PYTHON_VERSION python=$PYTHON_VERSION -y
+conda create -n py$PYTHON_VERSION python=$PYTHON_VERSION -y
 echo "conda activate py$PYTHON_VERSION" >> ~/.zshrc

--- a/scripts/devcontainer/post-create.sh
+++ b/scripts/devcontainer/post-create.sh
@@ -1,13 +1,12 @@
 #!/bin/zsh
 
 cat <<EOF >> ~/.zshrc
-reset_color='\e[0m'
 
 git() {
   if [[ \$# -ge 1 && "\$1" == "status" ]]; then
     echo "========= Run git stash list ========="
     var=\$(git stash list 2>&1)
-    echo -e "\033[35m \$var \$reset_color"
+    echo -e "\033[35m \$var \e[0m"
     echo "========= End git stash list ========="
     command git status
   else
@@ -40,5 +39,6 @@ curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/inst
 pip install pre-commit
 pre-commit install --hook-type commit-msg
 
-# Terraform autocomplete
-terraform -install-autocomplete
+if [ -x "$(command -v terraform --version)" ]; then
+  terraform -install-autocomplete
+fi


### PR DESCRIPTION
- Add Devcontainer feature version
- Change Dockerfile to use multi-stage builds for installing Miniconda3
- Fix pre-commit install-hooks not installing Hadolint binary [#886](https://github.com/hadolint/hadolint/issues/886)